### PR TITLE
Correção do formato das mensagens de sucesso e erro

### DIFF
--- a/resources/views/Alunos/cadastro-aluno.blade.php
+++ b/resources/views/Alunos/cadastro-aluno.blade.php
@@ -56,19 +56,10 @@
     }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
-    @if ($errors->any())
-    <div class="alert alert-danger">
-        <ul>
-            @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    </div>
-    @endif
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
 
     @if (session('sucesso'))
-    <div class="alert alert-sucess">
+    <div class="alert alert-sucess" style="width: 100%;">
         {{session('sucesso')}}
     </div>
     @endif

--- a/resources/views/Alunos/editar-aluno.blade.php
+++ b/resources/views/Alunos/editar-aluno.blade.php
@@ -56,19 +56,9 @@
     }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
-    @if ($errors->any())
-        <div class="alert alert-danger">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
-
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
     @if (session('sucesso'))
-        <div class="alert alert-danger">
+        <div class="alert alert-danger" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif

--- a/resources/views/Disciplina/editar.blade.php
+++ b/resources/views/Disciplina/editar.blade.php
@@ -2,19 +2,10 @@
 
 @section("body")
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
-    @if ($errors->any())
-        <div class="alert alert-danger">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
 
     @if (session('sucesso'))
-        <div class="alert alert-danger">
+        <div class="alert alert-danger" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif

--- a/resources/views/Edital/cadastrar.blade.php
+++ b/resources/views/Edital/cadastrar.blade.php
@@ -54,52 +54,52 @@
         width: 65%
     }
 </style>
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; ">
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
     @if (session('sucesso'))
-        <div class="alert alert-success">
+        <div class="alert alert-success" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif
     <br>
 
     <div class="boxchild">
-            <div class="row">
-                <h1 style="font-weight: 600; font-size: 30px; line-height: 47px; display: flex; align-items: center; color: #131833;">
-                    Cadastrar Edital</h1>
+        <div class="row">
+            <h1 style="font-weight: 600; font-size: 30px; line-height: 47px; display: flex; align-items: center; color: #131833;">
+            Cadastrar Edital</h1>
+        </div>
+
+        <hr>
+
+        <form action="{{route('editals.store')}}" method="post">
+            @csrf
+
+            <label for="data_inicio" class="titulo">Data de início:</label>
+            <input class="boxinfo" type="date" name="data_inicio" id="data_inicio" ><br><br>
+
+            <label for="data_fim" class="titulo">Data de fim:</label>
+            <input class="boxinfo"  type="date" name="data_fim" id="data_fim" id="data_inicio" ><br><br>
+
+            <label for="programa" class="titulo">Programa:</label>
+            <select aria-label="Default select example" class="boxinfo" name="programa" id="programa" >
+                <option value=""></option>
+                @foreach ($programas as $programa)
+                    <option value="{{$programa->id}}">{{$programa->nome}}</option>
+                @endforeach
+            </select><br><br>
+
+            <div style="display: flex; align-content: center; align-items: center; justify-content: center; gap:5%">
+                <input type="button" value="Voltar" href="{{url("/editals/")}}" onclick="window.location.href='{{url("/editals/")}}'" style="background: #2D3875;
+                box-shadow: 4px 5px 7px rgba(0, 0, 0, 0.25); display: inline-block;
+                border-radius: 13px; color: #FFFFFF; border: #2D3875; font-style: normal; font-weight: 400; font-size: 24px;
+                line-height: 29px; text-align: center; padding: 5px 15px;">
+                <input type="submit" value="Salvar" style="background: #34A853; box-shadow: 4px 5px 7px rgba(0, 0, 0, 0.25);
+                display: inline-block; border-radius: 13px; color: #FFFFFF; border: #34A853; font-style: normal;
+                font-weight: 400; font-size: 24px; line-height: 29px; text-align: center; padding: 5px 15px;">
             </div>
 
-            <hr>
-
-            <form action="{{route('editals.store')}}" method="post">
-                @csrf
-
-                <label for="data_inicio" class="titulo">Data de início:</label>
-                <input class="boxinfo" type="date" name="data_inicio" id="data_inicio" ><br><br>
-
-                <label for="data_fim" class="titulo">Data de fim:</label>
-                <input class="boxinfo"  type="date" name="data_fim" id="data_fim" id="data_inicio" ><br><br>
-
-                <label for="programa" class="titulo">Programa:</label>
-                <select aria-label="Default select example" class="boxinfo" name="programa" id="programa" >
-                    <option value=""></option>
-                    @foreach ($programas as $programa)
-                        <option value="{{$programa->id}}">{{$programa->nome}}</option>
-                    @endforeach
-                </select><br><br>
-
-                <div style="display: flex; align-content: center; align-items: center; justify-content: center; gap:5%">
-                    <input type="button" value="Voltar" href="{{url("/editals/")}}" onclick="window.location.href='{{url("/editals/")}}'" style="background: #2D3875;
-                                box-shadow: 4px 5px 7px rgba(0, 0, 0, 0.25); display: inline-block;
-                                border-radius: 13px; color: #FFFFFF; border: #2D3875; font-style: normal; font-weight: 400; font-size: 24px;
-                                line-height: 29px; text-align: center; padding: 5px 15px;">
-                    <input type="submit" value="Salvar" style="background: #34A853; box-shadow: 4px 5px 7px rgba(0, 0, 0, 0.25);
-                    display: inline-block; border-radius: 13px; color: #FFFFFF; border: #34A853; font-style: normal;
-                    font-weight: 400; font-size: 24px; line-height: 29px; text-align: center; padding: 5px 15px;">
-                </div>
 
 
-
-            </form>
+        </form>
     </div>
 </div>
 

--- a/resources/views/Edital/editar.blade.php
+++ b/resources/views/Edital/editar.blade.php
@@ -56,13 +56,13 @@
         width: 65%
     }
 </style>
-    <div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; ">
-    @if (session('sucesso'))
-        <div class="alert alert-success">
-            {{session('sucesso')}}
-        </div>
-    @endif
-    <br>
+    <div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
+        @if (session('sucesso'))
+            <div class="alert alert-success" style="width: 100%;">
+                {{session('sucesso')}}
+            </div>
+        @endif
+        <br>
         <div class="boxchild">
             <div class="row">
                 <h1 style="font-weight: 600; font-size: 30px; line-height: 47px; display: flex; align-items: center; color: #131833;">

--- a/resources/views/Edital/index.blade.php
+++ b/resources/views/Edital/index.blade.php
@@ -28,15 +28,15 @@
       background-color: #34A853;
     }
 
-  </style>
+</style>
 
-    <div class="container">
+<div class="container" style="font-family: 'Roboto', sans-serif;">
         @if (session('sucesso'))
             <div class="alert alert-success">
                 {{session('sucesso')}}
             </div>
         @endif
-    <br>
+  <br>
 
     <div style="margin-bottom: 10px;  gap: 20px; margin-top: 20px">
         <h1><strong>Editais</strong></h1>

--- a/resources/views/Orientador/cadastrar.blade.php
+++ b/resources/views/Orientador/cadastrar.blade.php
@@ -57,19 +57,9 @@
     }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
-    @if ($errors->any())
-        <div class="alert alert-danger">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
-
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
     @if (session('sucesso'))
-        <div class="alert alert-danger">
+        <div class="alert alert-danger" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif
@@ -100,7 +90,7 @@
             <input class="boxinfo" type="text" name="matricula" id="matricula" placeholder="Digite a matrícula"><br><br>
 
             <div style="display: flex; align-content: center; align-items: center; justify-content: center; gap:5%">
-                <input type="button" value="Voltar" href="{{route('home')}}" onclick="window.location.href='{{route('home')}}'"
+                <input type="button" value="Voltar" href="{{url("/orientadors/")}}" onclick="window.location.href='{{url("/orientadors/")}}'"
                 style="background: #2D3875; box-shadow: 4px 5px 7px rgba(0, 0, 0, 0.25); display: inline-block;
                 border-radius: 13px; color: #FFFFFF; border: #2D3875; font-style: normal; font-weight: 400; font-size: 24px;
                 line-height: 29px; text-align: center; padding: 5px 15px;">

--- a/resources/views/Orientador/editar-orientador.blade.php
+++ b/resources/views/Orientador/editar-orientador.blade.php
@@ -48,30 +48,19 @@
         box-shadow: inset 0px 3px 6px rgba(0, 0, 0, 0.25);
 
     }
-    .boxchild{
-        background: #FFFFFF;
-        box-shadow: 0px 6px 20px rgba(0, 0, 0, 0.25);
-        border-radius: 20px;
-        padding: 34px;
-        width: 65%
-    }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
 
     @if (session('sucesso'))
-        <div class="alert alert-success">
+        <div class="alert alert-success" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif
     <br>
 
-    <div class="boxchild">
-        <div class="row">
-            <h1 style="font-weight: 600; font-size: 30px; line-height: 47px; display: flex; align-items: center; color: #131833;">
-                Editar Orientador</h1>
-        </div>
-
+    <div style="background: #FFFFFF; box-shadow: 0px 6px 20px rgba(0, 0, 0, 0.25); border-radius: 20px; padding: 34px; width: 65%";>
+        <h1 style="font-weight: 600; font-size: 30px; line-height: 47px; display: flex; align-items: center; color: #131833;">Editar Orientador</h1>
         <hr>
         <form action="{{url("/orientadors/$orientador->id")}}" method="POST">
             @csrf

--- a/resources/views/Orientador/index.blade.php
+++ b/resources/views/Orientador/index.blade.php
@@ -32,10 +32,10 @@
 
 
   @can('servidor')
-  <div class="container">
+  <div class="container" style="font-family: 'Roboto', sans-serif;">
     @if (session('sucesso'))
     <div class="alert alert-success">
-        {{session('sucesso')}}
+      {{session('sucesso')}}
     </div>
     @endif
     <br>

--- a/resources/views/Programa/cadastrar.blade.php
+++ b/resources/views/Programa/cadastrar.blade.php
@@ -57,10 +57,10 @@
     }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
 
     @if (session('sucesso'))
-        <div class="alert alert-success">
+        <div class="alert alert-success" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif

--- a/resources/views/Programa/editar.blade.php
+++ b/resources/views/Programa/editar.blade.php
@@ -57,10 +57,10 @@
     }
 </style>
 
-<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px">
+<div class="container" style="display: flex; justify-content: center; align-items: center; margin-top: 1em; margin-bottom:10px; flex-direction: column;">
 
     @if (session('sucesso'))
-        <div class="alert alert-success">
+        <div class="alert alert-success" style="width: 100%;">
             {{session('sucesso')}}
         </div>
     @endif


### PR DESCRIPTION
Consegui deixar todas as mensagens no mesmo formato e sem duplicação.  Porém, as telas de orientador e disciplina apresentam as mensagens de sucesso nas telas de editar e cadastrar, enquanto as outras telas apresentam a mensagem na tela de listar. Não sei se é um problema ou não, tentei encontrar o motivo para que isso esteja acontecendo e não achei nada.

![Captura de tela_20230126_170138](https://user-images.githubusercontent.com/80794452/214949130-dbfef573-d007-4c46-9fab-066d148d9f26.png)
![Captura de tela_20230126_170016](https://user-images.githubusercontent.com/80794452/214949176-a7ffa340-8da5-4d2d-8ab4-a7177f84b2a5.png)
![Captura de tela_20230126_170304](https://user-images.githubusercontent.com/80794452/214950687-c01984e5-4cb9-4292-95f1-0f695abd65b4.png)
![Captura de tela_20230126_171031](https://user-images.githubusercontent.com/80794452/214950769-62585bc8-71d2-4030-9032-65899db31f1b.png)
![Captura de tela_20230126_170559](https://user-images.githubusercontent.com/80794452/214949390-87162b38-70a0-4bfe-ad45-ef2bb13ae6b5.png)
